### PR TITLE
ci: enforce Conventional Commits on PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,22 @@
+# Enforce Conventional Commits 1.0.0 on PR titles (see CONTRIBUTING.md).
+#
+# This repo squash-merges, so the PR title becomes the commit subject on
+# `main` — making the title the single thing worth enforcing. Individual
+# commit messages are collapsed at squash and are intentionally not policed.
+#
+# Runs as `pull_request_target` so it also validates forked / Dependabot PRs;
+# it only reads the title and never checks out PR code, so this is safe.
+name: PR Title
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+permissions:
+  pull-requests: read
+jobs:
+  validate:
+    name: Validate conventional title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing
+
+Thanks for contributing to `pro_sports_transactions`!
+
+## Pull request titles
+
+This repository **squash-merges** pull requests, so the **PR title becomes the
+commit subject on `main`**. PR titles must follow
+[Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) and
+are validated automatically by the [PR Title](.github/workflows/pr-title.yml)
+workflow. Individual commit messages within a PR are collapsed at squash and are
+not policed — only the title matters.
+
+The format is:
+
+```
+<type>[optional scope]: <description>
+```
+
+Examples:
+
+```
+feat: add cloudscraper request handler
+fix(search): handle empty response body
+docs: document the unflare handler
+chore(deps): bump aiohttp to 3.13.3
+```
+
+### Allowed types
+
+| Type       | Use for                                                        |
+| ---------- | -------------------------------------------------------------- |
+| `feat`     | A new feature                                                  |
+| `fix`      | A bug fix                                                      |
+| `docs`     | Documentation only changes                                     |
+| `style`    | Formatting, whitespace — no code-behavior change               |
+| `refactor` | A code change that neither fixes a bug nor adds a feature      |
+| `perf`     | A change that improves performance                             |
+| `test`     | Adding or correcting tests                                     |
+| `build`    | Changes to the build system or dependencies                   |
+| `ci`       | Changes to CI configuration and scripts                        |
+| `chore`    | Other changes that don't modify `src` or `test` files         |
+| `revert`   | Reverts a previous commit                                      |
+
+A breaking change is marked with a `!` after the type/scope (e.g. `feat!:`) or a
+`BREAKING CHANGE:` footer.


### PR DESCRIPTION
## What

Adds a `PR Title` GitHub Actions workflow that validates every pull request title against [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/), plus a `CONTRIBUTING.md` documenting the convention and allowed types.

## Why

This is the first of several restructuring PRs. Landing title validation first sets the naming convention that every subsequent PR must follow. The repo squash-merges, so the PR title becomes the commit subject on `main` — making the title the one thing worth enforcing.

## Details

- **`.github/workflows/pr-title.yml`** — uses `amannn/action-semantic-pull-request@v6`, runs as `pull_request_target` so it also covers forked/Dependabot PRs (reads the title only, never checks out PR code).
- **`CONTRIBUTING.md`** — documents the format and the allowed types (`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`).

Adapted from a monorepo template; the `CLAUDE.md` reference was repointed to `CONTRIBUTING.md`.

> Note: assumes the repo is set to **squash-merge**. If not, enable it in Settings → General → Pull Requests, or the "title becomes the commit subject" rationale doesn't hold.