### PR TITLE
ci: stabilize on Python 3.11-3.14 before the uv/ruff migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+# CI — run the unit test suite across every supported Python version.
+#
+# The published package supports Python >=3.11, so the `test` matrix runs the
+# suite on each currently-supported CPython (3.11–3.14) to guarantee that
+# support contract. When the floor moves (e.g. 3.11 reaches EOL), drop that leg
+# and bump the Python floor + classifiers in pyproject.toml.
+#
+# `ci` is an aggregate gate job: make THIS the required status check in branch
+# protection. It reports a single stable name ("CI") regardless of how many
+# matrix legs exist, so adding/removing a Python version never breaks branch
+# protection config — and it stays stable when the toolchain moves to uv.
+
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # one version failing still reports the others
+      matrix:
+        python-version: ['3.11', '3.12', '3.13', '3.14']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Poetry
+        run: pipx install poetry
+      - name: Install dependencies
+        run: poetry install
+      - name: Test
+        run: poetry run pytest
+
+  # Aggregate gate for branch protection. Passes when every job succeeded or was
+  # skipped; fails otherwise. Set this ("CI") as the required status check.
+  ci:
+    name: CI
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all jobs passed
+        run: |
+          for r in ${{ needs.test.result }}; do
+            if [ "$r" != "success" ] && [ "$r" != "skipped" ]; then
+              echo "Job failed: $r"
+              exit 1
+            fi
+          done
+          echo "All jobs passed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- CI workflow running the unit test suite across Python 3.11–3.14 on every pull request
+- Python version Trove classifiers (3.11–3.14) advertising the supported release range
+
+### Fixed
+- Unit tests resolve their HTML response fixtures relative to the test file instead of a hardcoded absolute path, so the suite runs outside the original dev container (e.g. in CI)
+
 ## [1.1.2] - 2026-02-07
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Software Development",
 ]
 

--- a/tests/unit/test_search_responses.py
+++ b/tests/unit/test_search_responses.py
@@ -1,9 +1,13 @@
 """Unit tests for search response handling."""
 
+from pathlib import Path
+
 import pytest
 
 import pro_sports_transactions as pst
 from pro_sports_transactions.search import TransactionType
+
+DATA_DIR = Path(__file__).parent / "data"
 
 
 @pytest.fixture
@@ -34,7 +38,7 @@ def mock_valid_reponse(create_mock_coro):  # pylint: disable=redefined-outer-nam
     response = None
     # read https://www.prosportstransactions.com/ search results
     with open(
-        r"/workspaces/pro_sports_transactions/tests/unit/data/valid_response.html",
+        DATA_DIR / "valid_response.html",
         mode="r",
         encoding="utf-8",
     ) as f:
@@ -52,7 +56,7 @@ def mock_empty_reponse(create_mock_coro):  # pylint: disable=redefined-outer-nam
     response = None
     # read https://www.prosportstransactions.com/ search results
     with open(
-        r"/workspaces/pro_sports_transactions/tests/unit/data/empty_response.html",
+        DATA_DIR / "empty_response.html",
         mode="r",
         encoding="utf-8",
     ) as f:


### PR DESCRIPTION
## Stabilize before upgrade

First step of the repo restructure. The principle is **stabilize the current
stack, then upgrade it** — establish a green CI safety net and fix a latent bug
on the existing Poetry toolchain *before* migrating to uv/ruff (which follows in
#23, rebased on top of this).

### What's here
- **`test:`** Unit tests loaded their HTML fixtures from a hardcoded absolute
  container path, so the suite only ran inside the original devcontainer. They
  now resolve fixtures relative to the test file — a prerequisite for running in
  CI at all.
- **`build:`** Add `Programming Language :: Python :: 3.11–3.14` Trove
  classifiers so published metadata matches the support contract CI now proves.
- **`ci:`** New `CI` workflow running `pytest` across Python 3.11–3.14 on every
  PR, with an aggregate `CI` gate job as the stable required-status-check name.

### Notes
- The CI here runs on the **current Poetry stack** on purpose — it proves the
  code is healthy on every supported Python before anything changes. #23
  converts this same workflow to uv and adds lint + a lowest-direct
  dependency-floor leg; the `CI` gate name stays stable across that change.
- Deliberately **no lint job** yet: black/flake8/isort/pylint are replaced by
  ruff in #23, so wiring them here would be pure throwaway.

Set the `CI` check as required in branch protection once this merges.
