### PR TITLE
build: persist Claude Code history and add gh to the dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,14 @@
         // This allows Docker to access project files outside the .devcontainer directory
         "context": ".."
     },
-    
+
+    // Dev container features layered onto the image. The github-cli feature
+    // installs `gh` via the devcontainers-maintained recipe, avoiding a manual
+    // apt/gpg setup in the Dockerfile.
+    "features": {
+        "ghcr.io/devcontainers/features/github-cli:1": {}
+    },
+
     // VS Code specific customizations
     "customizations": {
         "vscode": {
@@ -54,7 +61,15 @@
     
     // Use host networking to access services (e.g. unflare) running on host
     "runArgs": ["--network=host"],
-    
+
+    // Persist Claude Code state across container rebuilds. A named volume backs
+    // ~/.claude (session history, per-project data, and memory) so it survives
+    // "Rebuild Container". post_create_command.sh fixes its ownership since
+    // named volumes are created root-owned.
+    "mounts": [
+        "source=pst-claude-home,target=/home/vscode/.claude,type=volume"
+    ],
+
     // User to connect as when attaching to the container
     // "vscode" user has proper permissions and development tools pre-configured
     "remoteUser": "vscode",

--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -8,6 +8,11 @@ set -e
 # Display status message to user during container setup
 echo "Setting up development environment..."
 
+# The ~/.claude directory is backed by a named volume (see devcontainer.json)
+# so Claude Code history/memory survives rebuilds. Named volumes mount
+# root-owned on first creation, so hand ownership to the vscode user.
+sudo chown -R vscode:vscode /home/vscode/.claude 2>/dev/null || true
+
 # Install all dependencies (including the dev group) from pyproject.toml and
 # uv.lock into ./.venv. --frozen fails loudly if the lock is out of sync rather
 # than silently re-resolving, so the container matches CI exactly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - CI workflow running the unit test suite across Python 3.11–3.14 on every pull request
 - Python version Trove classifiers (3.11–3.14) advertising the supported release range
+- Dev container persists Claude Code history and memory across rebuilds (named volume on `~/.claude`) and installs the GitHub CLI via the `github-cli` dev container feature
 
 ### Changed
 - Migrated the project toolchain from Poetry to [uv](https://docs.astral.sh/uv/) (`uv.lock` replaces `poetry.lock`; build backend is now hatchling)


### PR DESCRIPTION
## Dev container DX: persist Claude Code + add gh

Final step of the restructure — developer-environment quality-of-life on top of
the uv dev container from #23.

### What's here
- **Persist Claude Code across rebuilds.** A named volume (`pst-claude-home`)
  backs `~/.claude`, so session history, per-project data, and memory survive
  "Rebuild Container" instead of being wiped each time. `post_create_command.sh`
  chowns the mount to `vscode` (named volumes are created root-owned).
- **GitHub CLI.** Installed via the devcontainers-maintained
  `ghcr.io/devcontainers/features/github-cli` feature rather than a hand-rolled
  apt/gpg block in the Dockerfile — more robust and less to maintain.

### Notes
- Container-only change: it takes effect on **Rebuild Container**, and CI does
  not build the dev container, so there's nothing for the matrix to exercise
  here. Validated for config correctness (JSONC parses, `bash -n` clean).
- Base image stays on **Python 3.11** (unchanged from #23). No OS bump
  (bullseye→trixie) — deliberately out of scope to keep this low-risk.

### Restructure series (this completes it)
1. #22 — Conventional-Commits PR-title check *(merged)*
2. #24 — Stabilize: Poetry CI matrix + fixture fix + classifiers *(merged)*
3. #23 — Migrate to uv + Ruff + pandas floor fix *(merged)*
4. **this** — Dev container DX
