### PR TITLE
fix: resolve default search dates at call time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Raised the pandas floor to `>=2.2.2` (the first release with numpy 2 support) so the declared minimum resolves against modern numpy; a `--resolution lowest-direct` CI leg now guards it
 
 ### Fixed
+- `Search` and `UrlBuilder.build` now resolve their default `start_date`/`end_date` at call time instead of freezing `date.today()` at import time, so a long-lived process no longer defaults to its import-day date ([#27](https://github.com/rsforbes/pro_sports_transactions/issues/27))
 - Unit tests resolve their HTML response fixtures relative to the test file instead of a hardcoded absolute path, so the suite runs outside the original dev container (e.g. in CI)
 
 ## [1.1.2] - 2026-02-07

--- a/src/pro_sports_transactions/search.py
+++ b/src/pro_sports_transactions/search.py
@@ -54,13 +54,20 @@ class Search:
         self,
         league: League = League.NBA,
         transaction_types: TransactionType = (),
-        start_date: date = date.today(),
-        end_date: date = date.today(),
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
         player: str = None,
         team: str = None,
         starting_row: int = 0,
         request_handler: Optional[RequestHandler] = None,
     ):
+        # Resolve date defaults at call time. Using date.today() as an argument
+        # default would freeze the value at import time (evaluated once), so a
+        # long-lived process would keep defaulting to its import day.
+        if start_date is None:
+            start_date = date.today()
+        if end_date is None:
+            end_date = date.today()
         self._url = UrlBuilder.build(
             league=league,
             transaction_types=transaction_types,
@@ -194,13 +201,18 @@ class UrlBuilder:
     def build(
         league=League.NBA,
         transaction_types=(),
-        start_date: date = date.today(),
-        end_date: date = date.today(),
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
         player=None,
         team=None,
         starting_row=None,
     ):
         """Build search URL with given parameters."""
+        # Resolve date defaults at call time (see Search.__init__).
+        if start_date is None:
+            start_date = date.today()
+        if end_date is None:
+            end_date = date.today()
         params = {}
         params |= Parameter.start_date(start_date)
         params |= Parameter.end_date(end_date)

--- a/tests/unit/test_build_url.py
+++ b/tests/unit/test_build_url.py
@@ -59,3 +59,27 @@ def test_build_url(league_param: League):
     assert expected.netloc == actual.netloc
     assert expected.path == actual.path
     assert parse.parse_qs(actual.query) == parse.parse_qs(expected.query)
+
+
+@pytest.mark.unit
+def test_default_dates_resolved_at_call_time(monkeypatch):
+    """Default start/end dates must be evaluated per call, not frozen at import.
+
+    Regression test for date.today() used as an argument default, which Python
+    evaluates once at import time. Patch the module's date so today() returns a
+    fixed value, then assert the URL built with default dates reflects it —
+    proving the default is read when build() runs, not when the module loaded.
+    """
+    from pro_sports_transactions import search as search_module
+
+    class FixedDate(date):
+        @classmethod
+        def today(cls):
+            return cls(2030, 1, 2)
+
+    monkeypatch.setattr(search_module, "date", FixedDate)
+
+    query = parse.parse_qs(parse.urlparse(UrlBuilder.build()).query)
+
+    assert query["BeginDate"] == ["2030-01-02"]
+    assert query["EndDate"] == ["2030-01-02"]


### PR DESCRIPTION
## Resolve default search dates at call time

Closes #27.

### The bug
`Search.__init__` and `UrlBuilder.build` defaulted `start_date`/`end_date` to
`date.today()` **in the argument defaults**. Python evaluates default arguments
once, at function-definition (import) time — so the defaults froze to the
module's import day and never updated. A long-lived process (web service,
notebook kernel, cron worker) would keep searching its import-day window. Latent
in the suite only because every existing test passes explicit dates.

### The fix
Default the parameters to `None` and compute `date.today()` inside the body, so
it's evaluated per call. Applied at both sites (`UrlBuilder.build` is a public
`@staticmethod` callable directly, so it needs its own guard).

### Test
`test_default_dates_resolved_at_call_time` patches the module's `date` so
`today()` returns a fixed value, then asserts the URL built with default dates
reflects it. Verified it **fails on the pre-fix code** and passes after — a true
regression test. Full suite: 64 passed.

### Scope
Behavior-changing (the default now reflects call time), hence its own PR rather
than riding along with the toolchain migration. Enabling Ruff's flake8-bugbear
`B` — which flags this `B008` pattern to prevent regressions — follows in a
separate PR once this lands.
