### PR TITLE
build: enable Ruff's flake8-bugbear (B) lint rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated the project toolchain from Poetry to [uv](https://docs.astral.sh/uv/) (`uv.lock` replaces `poetry.lock`; build backend is now hatchling)
 - Replaced black, flake8, isort, and pylint with [Ruff](https://docs.astral.sh/ruff/) for formatting and linting
 - Raised the pandas floor to `>=2.2.2` (the first release with numpy 2 support) so the declared minimum resolves against modern numpy; a `--resolution lowest-direct` CI leg now guards it
+- Enabled Ruff's flake8-bugbear (`B`) lint rules to catch likely-bug patterns (e.g. function calls in argument defaults)
 
 ### Fixed
 - `Search` and `UrlBuilder.build` now resolve their default `start_date`/`end_date` at call time instead of freezing `date.today()` at import time, so a long-lived process no longer defaults to its import-day date ([#27](https://github.com/rsforbes/pro_sports_transactions/issues/27))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,11 +84,12 @@ src = ["src", "tests"]
 
 [tool.ruff.lint]
 # E/W pycodestyle, F pyflakes, I isort — mirrors what the prior
-# black + flake8 + isort stack actually enforced. E203 and E501 are owned by
-# the formatter (line wrapping), so they're disabled here to avoid
-# double-reporting. (flake8-bugbear "B" was listed in the old .flake8 select but
-# the plugin was never installed, so it never ran — adopting it is a follow-up.)
-select = ["E", "F", "W", "I"]
+# black + flake8 + isort stack actually enforced. B is flake8-bugbear (likely
+# bug patterns); it was listed in the old .flake8 select but the plugin was
+# never installed, so it never actually ran until now. E203 and E501 are owned
+# by the formatter (line wrapping), so they're disabled here to avoid
+# double-reporting.
+select = ["E", "F", "W", "I", "B"]
 ignore = ["E203", "E501"]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
## Enable Ruff's flake8-bugbear (`B`)

Follow-up to #28. Adds `"B"` to the Ruff lint `select` so flake8-bugbear runs
in CI, catching likely-bug patterns going forward (e.g. `B008` — function calls
in argument defaults).

### Why now
The old `.flake8` listed bugbear in its select but never installed the plugin,
so it had **never actually run**. The only violation it surfaces in this
codebase — the `date.today()` argument defaults (`B008`) — was fixed in #28, so
`main` is already clean under `B`. This PR just turns the door lock so that
class of bug can't be reintroduced.

### Verification
`ruff check .` passes with `B` enabled (no findings); full lint + test matrix
green. Confirmed `B008` was the *only* `B` violation repo-wide.

### Scope
Config-only (one line in `pyproject.toml` + a CHANGELOG note). Deliberately not
bundled with the #28 fix so the behavior change and the lint-policy change stay
separately reviewable/revertable.
