### PR TITLE
ci: add Dependabot config for uv and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Dependabot configuration.
+#
+# Two ecosystems: the uv-managed Python dependencies (pyproject.toml + uv.lock
+# at the repo root) and the GitHub Actions used in workflows.
+#
+# commit-message matters here: this repo enforces Conventional Commits on PR
+# titles (see .github/workflows/pr-title.yml), and Dependabot's default
+# "Bump X from A to B" titles would fail that check. `prefix` applies to both
+# commit messages and PR titles; `include: "scope"` appends the dependency scope
+# so Dependabot emits "<prefix>(deps): bump ..." for runtime deps and
+# "<prefix>(deps-dev): bump ..." for dev-group deps — both valid Conventional
+# Commit titles that pass the check.
+version: 2
+updates:
+  # Python dependencies managed by uv.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      # Collapse minor/patch bumps into a single weekly PR to cut noise; major
+      # updates still come as individual PRs so breaking changes get their own
+      # review.
+      python-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # GitHub Actions referenced in .github/workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI workflow running the unit test suite across Python 3.11–3.14 on every pull request
 - Python version Trove classifiers (3.11–3.14) advertising the supported release range
 - Dev container persists Claude Code history and memory across rebuilds (named volume on `~/.claude`) and installs the GitHub CLI via the `github-cli` dev container feature
+- Dependabot configuration for weekly uv and GitHub Actions dependency updates (minor/patch bumps grouped, Conventional-Commit PR titles)
 
 ### Changed
 - Migrated the project toolchain from Poetry to [uv](https://docs.astral.sh/uv/) (`uv.lock` replaces `poetry.lock`; build backend is now hatchling)


### PR DESCRIPTION
## Dependabot configuration

Formalizes dependency automation for the two ecosystems this repo uses.

### What's configured
- **uv** (Python deps — `pyproject.toml` + `uv.lock` at root): weekly, minor/
  patch bumps **grouped** into one PR to cut noise, majors stay individual for
  review. Limit 10 open PRs.
- **github-actions** (workflow actions): weekly, all grouped.

### Conventional-Commit titles
This repo enforces Conventional Commits on PR titles, and Dependabot's default
`Bump X from A to B` titles fail that check (as the current open Dependabot PRs
show). Setting `commit-message.prefix` makes Dependabot emit
`build(deps): bump ...` / `ci(deps): bump ...` (and `(deps-dev)` for dev-group
updates), which pass the `amannn` title validator.

### Notes
- Config-only; nothing for CI to exercise (Dependabot runs on GitHub's schedule,
  not in this workflow). Validated: YAML parses, version 2, both ecosystems.
- Existing open Dependabot PRs (#16/#20/#21) keep their old non-conventional
  titles — worth rebasing/recreating or just editing their titles so they pass
  the title check. New ones will be compliant automatically.
