### PR TITLE
fix: mount dev container repo at /workspace so uv sync can create the venv

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,14 @@
         "context": ".."
     },
 
+    // Mount the repo at /workspace (not the CLI default /workspaces/<repo>) so it
+    // matches the Dockerfile's WORKDIR and UV_PROJECT_ENVIRONMENT=/workspace/.venv,
+    // the interpreter path below, and the .bashrc activation line. Without this the
+    // default mount lands elsewhere and /workspace is a stray root-owned dir, so
+    // `uv sync` in post-create fails to create /workspace/.venv (Permission denied).
+    "workspaceFolder": "/workspace",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+
     // Dev container features layered onto the image. The github-cli feature
     // installs `gh` via the devcontainers-maintained recipe, avoiding a manual
     // apt/gpg setup in the Dockerfile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `Search` and `UrlBuilder.build` now resolve their default `start_date`/`end_date` at call time instead of freezing `date.today()` at import time, so a long-lived process no longer defaults to its import-day date ([#27](https://github.com/rsforbes/pro_sports_transactions/issues/27))
 - Unit tests resolve their HTML response fixtures relative to the test file instead of a hardcoded absolute path, so the suite runs outside the original dev container (e.g. in CI)
+- Dev container now mounts the repo at `/workspace` (via `workspaceFolder`/`workspaceMount`) to match the Dockerfile's `WORKDIR` and `UV_PROJECT_ENVIRONMENT`, so `uv sync` in post-create no longer fails with `Permission denied` creating `/workspace/.venv` on a clean rebuild
 
 ## [1.1.2] - 2026-02-07
 


### PR DESCRIPTION
## Problem

A clean dev container rebuild fails in `post_create_command.sh`:

```
error: failed to create directory `/workspace/.venv`: Permission denied (os error 13)
[...] postCreateCommand from devcontainer.json failed with exit code 2
```

## Root cause

The `Dockerfile` commits to `/workspace` in two places — `WORKDIR /workspace` and `UV_PROJECT_ENVIRONMENT="/workspace/.venv"` — but `devcontainer.json` set **no** `workspaceFolder`/`workspaceMount`. The Dev Containers CLI therefore mounts the repo at its default location (`/workspaces/<repo>`), leaving `/workspace` as an empty, **root-owned** directory created by the `WORKDIR` instruction.

When post-create runs `uv sync --frozen` as the `vscode` user, uv honors `UV_PROJECT_ENVIRONMENT` and tries to create `/workspace/.venv` inside that root-owned dir → `Permission denied`. Latent regression from the uv migration (#23); only bites on a fresh rebuild.

## Fix

Pin the mount to `/workspace` so it's the actual (vscode-owned, writable) bind mount and matches every `/workspace` reference already in the config — WORKDIR, `UV_PROJECT_ENVIRONMENT`, the interpreter path, and the `.bashrc` activation line:

```jsonc
"workspaceFolder": "/workspace",
"workspaceMount": "source=\${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
```

`.venv` is already gitignored, so nothing leaks into the repo.

## Verification

Config-only change with no runtime surface to drive from CI — validate by **Dev Containers: Rebuild Container**; post-create should reach "Setup complete!".