### PR TITLE
build: upgrade pytest to 9 and pytest-asyncio to 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced black, flake8, isort, and pylint with [Ruff](https://docs.astral.sh/ruff/) for formatting and linting
 - Raised the pandas floor to `>=2.2.2` (the first release with numpy 2 support) so the declared minimum resolves against modern numpy; a `--resolution lowest-direct` CI leg now guards it
 - Enabled Ruff's flake8-bugbear (`B`) lint rules to catch likely-bug patterns (e.g. function calls in argument defaults)
+- Upgraded the test stack to pytest 9 (`>=9.0,<10`), pytest-asyncio 1.x (`>=1.3,<2`), and pytest-mock (`>=3.14,<4`); pinned `asyncio_mode = "strict"` to match the suite's explicit `@pytest.mark.asyncio` markers. The full unit suite passes at both the declared floors and the latest versions
 
 ### Fixed
 - `Search` and `UrlBuilder.build` now resolve their default `start_date`/`end_date` at call time instead of freezing `date.today()` at import time, so a long-lived process no longer defaults to its import-day date ([#27](https://github.com/rsforbes/pro_sports_transactions/issues/27))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,9 @@ Documentation = "https://github.com/rsforbes/pro_sports_transactions/blob/main/R
 
 [dependency-groups]
 dev = [
-  "pytest>=7.3.1,<8",
-  "pytest-asyncio>=0.21.0,<0.22",
-  "pytest-mock>=3.10.0,<4",
+  "pytest>=9.0,<10",
+  "pytest-asyncio>=1.3,<2",
+  "pytest-mock>=3.14,<4",
   "ruff>=0.15.4",
 ]
 
@@ -98,6 +98,10 @@ known-first-party = ["pro_sports_transactions"]
 [tool.pytest.ini_options]
 testpaths = ["tests/unit"]
 pythonpath = ["src"]
+
+# Async tests use explicit @pytest.mark.asyncio markers; pin strict mode so the
+# suite doesn't depend on it remaining pytest-asyncio's default.
+asyncio_mode = "strict"
 
 # Markers for different test types
 addopts = "--strict-markers"

--- a/uv.lock
+++ b/uv.lock
@@ -831,9 +831,9 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = ">=7.3.1,<8" },
-    { name = "pytest-asyncio", specifier = ">=0.21.0,<0.22" },
-    { name = "pytest-mock", specifier = ">=3.10.0,<4" },
+    { name = "pytest", specifier = ">=9.0,<10" },
+    { name = "pytest-asyncio", specifier = ">=1.3,<2" },
+    { name = "pytest-mock", specifier = ">=3.14,<4" },
     { name = "ruff", specifier = ">=0.15.4" },
 ]
 
@@ -949,30 +949,41 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pytest"
-version = "7.4.4"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287, upload-time = "2023-12-31T12:00:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.21.2"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/53/57663d99acaac2fcdafdc697e52a9b1b7d6fcf36616281ff9768a44e7ff3/pytest_asyncio-0.21.2.tar.gz", hash = "sha256:d67738fc232b94b326b9d060750beb16e0074210b98dd8b58a5239fa2a154f45", size = 30656, upload-time = "2024-04-29T13:23:24.738Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/ce/1e4b53c213dce25d6e8b163697fbce2d43799d76fa08eea6ad270451c370/pytest_asyncio-0.21.2-py3-none-any.whl", hash = "sha256:ab664c88bb7998f711d8039cacd4884da6430886ae8bbd4eded552ed2004f16b", size = 13368, upload-time = "2024-04-29T13:23:23.126Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Moves the test stack forward two majors, deliberately (rather than taking Dependabot's major bumps blind).

## Changes
| Package | Before | Now (constraint) | Locked |
|---|---|---|---|
| pytest | `>=7.3.1,<8` (7.4.4) | `>=9.0,<10` | 9.1.1 |
| pytest-asyncio | `>=0.21.0,<0.22` (0.21.2) | `>=1.3,<2` | 1.4.0 |
| pytest-mock | `>=3.10.0,<4` (3.15.1) | `>=3.14,<4` | 3.15.1 |

Also pins `asyncio_mode = "strict"` in `[tool.pytest.ini_options]`.

## Why this is a low-risk bump
The big breaker in the pytest-asyncio 0.23/1.0 rewrite is the removal of `event_loop` fixture overrides and the loop-scope changes for **async fixtures**. This suite has:
- **no** `event_loop` overrides
- **no** async fixtures (`pytest_asyncio.fixture`)
- **no** `conftest.py`
- async tests are plain `@pytest.mark.asyncio` on `async def` — the portable pattern

`addopts` is only `--strict-markers` (no `-W error`), so new deprecation warnings don't fail the run. The pre-existing pandas `read_html` `FutureWarning` is unrelated and unchanged.

The pytest-asyncio floor is `>=1.3` (not `>=1.0`) because 1.0–1.2 cap `pytest<9`; 1.3.0 is the true minimum that admits pytest 9.

## Verification
All 64 unit tests pass at **both** ends of the declared range:
- **Floors** via `uv sync --resolution lowest-direct` → pytest 9.0.0 / pytest-asyncio 1.3.0 / pytest-mock 3.14.0 → 64 passed
- **Latest** locked → pytest 9.1.1 / pytest-asyncio 1.4.0 / pytest-mock 3.15.1 → 64 passed

`ruff check` clean.

## Supersedes
Closes out the Dependabot pytest-major PRs: #33, #25, #16.