### PR TITLE
build: commit dev container Features lockfile

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}


### PR DESCRIPTION
## What

Commits `.devcontainer/devcontainer-lock.json`, the Dev Containers lockfile that the tooling generates when `devcontainer.json` declares `features`.

## Why

`devcontainer.json` requests the Feature by floating major version (`ghcr.io/devcontainers/features/github-cli:1`). The lockfile pins the exact resolved version and image digest (`github-cli 1.1.0`, `sha256:d22f50b7…`) so container rebuilds are reproducible instead of silently picking up a newer `1.x`. Same rationale as committing `uv.lock`.

It is machine-generated by the Dev Containers tooling — not hand-edited.

## Scope

Single file. No code or CI changes.